### PR TITLE
Support sqlite as well, generalize db config a bit.

### DIFF
--- a/roundcube/init.sls
+++ b/roundcube/init.sls
@@ -1,5 +1,7 @@
-{% from 'roundcube/map.jinja' import roundcube with context %}
-{% from 'selinux/map.jinja' import selinux with context %}
+{%- from 'roundcube/map.jinja' import roundcube with context %}
+{%- from 'selinux/map.jinja' import selinux with context %}
+
+{%- set db_type = roundcube.get('config', {}).get('db_dsnw', 'pgsql://').split(':') | first -%}
 
 include:
   - epel
@@ -9,8 +11,14 @@ include:
   - php.ng.mbstring
   - php.ng.xml
   - php.ng.pear
-  - php.ng.{{ 'mysql' if roundcube.get('config', {}).get('db_dsnw').startswith('mysql') else 'pgsql' }}
-{% if selinux.enabled %}
+{%- if db_type in ['mysql', 'mysqli'] %}
+  - php.ng.mysql
+{%- elif db_type == 'sqlite' %}
+  - php.ng.sqlite
+{%- elif db_type == 'pgsql' %}
+  - php.ng.pgsql
+{%- endif %}
+{%- if selinux.enabled %}
   - .selinux
 {% endif %}
 

--- a/roundcube/map.jinja
+++ b/roundcube/map.jinja
@@ -13,10 +13,16 @@
 }) %}
 
 {% if roundcube.get('db') %}
-{% set db = roundcube.db %}
-{% do roundcube.config.update({
+{%   set db = roundcube.db %}
+{%   if db.type in ['mysql', 'mysqli', 'pgsql'] %}
+{%     do roundcube.config.update({
   'db_dsnw': db.type + '://' + db.username + ':' + db.password + '@' + db.host + '/' + db.database
 }) %}
+{%   elif db.type == 'sqlite' %}
+{%     do roundcube.config.update({
+  'db_dsnw': '{dbtype}:///{database}?mode={permissions}'.format(dbtype=db.type, database=db.database, permissions=db.get('permissions', '0644'))
+}) %}
+{%   endif %}
 {% endif %}
 
 {% if roundcube.get('plugins') %}


### PR DESCRIPTION
The DB config assumed that roundcube will either be using mysql or
postgresql.
This commit removes some ternary if/else constructs and adds support
for sqlite as well.

Drive-By: Change Jinja commands without input to fold newlines instead.