### PR TITLE
Use cmd.wait instead of cmd.run

### DIFF
--- a/roundcube/imapproxy.sls
+++ b/roundcube/imapproxy.sls
@@ -24,7 +24,7 @@ imapproxy-config-{{ key }}:
 {% endfor %}
 
 imapproxy-trim-whitespaces:
-  cmd.run:
+  cmd.wait:
     - name: "sed 's/^[ \t]*//' --in-place /etc/imapproxy.conf"
     - watch:
       - pkg: imapproxy


### PR DESCRIPTION
The sed call to remove whitespace in the imapproxy config is run
every time salt runs. This is unnecessary.
Fix by using cmd.wait, which will only run the sed call after the
file has actually changed.
cmd.run will run every time _and_ when the file has changed. cmd.wait
will not.